### PR TITLE
Implement basic screenshot extension

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,0 +1,36 @@
+chrome.runtime.onMessage.addListener(async (message, sender, sendResponse) => {
+  if (message.type === 'capture') {
+    const tabId = sender.tab.id;
+    const imageUri = await chrome.tabs.captureVisibleTab(sender.tab.windowId, {
+      format: 'png'
+    });
+    const img = new Image();
+    img.src = imageUri;
+    img.onload = () => {
+      const canvas = new OffscreenCanvas(message.rect.width + message.padding * 2,
+        message.rect.height + message.padding * 2);
+      const ctx = canvas.getContext('2d');
+      ctx.drawImage(
+        img,
+        message.rect.left - message.padding,
+        message.rect.top - message.padding,
+        canvas.width,
+        canvas.height,
+        0,
+        0,
+        canvas.width,
+        canvas.height
+      );
+      canvas.convertToBlob({ type: 'image/png' }).then(blob => {
+        const reader = new FileReader();
+        reader.onload = () => {
+          chrome.tabs.sendMessage(tabId, {
+            type: 'screenshot-captured',
+            dataUrl: reader.result
+          });
+        };
+        reader.readAsDataURL(blob);
+      });
+    };
+  }
+});

--- a/contentScript.js
+++ b/contentScript.js
@@ -1,0 +1,74 @@
+let currentOverlay;
+let currentTarget;
+let padding = 0;
+
+function createOverlay(rect) {
+  const overlay = document.createElement('div');
+  overlay.style.position = 'absolute';
+  overlay.style.top = `${rect.top + window.scrollY - padding}px`;
+  overlay.style.left = `${rect.left + window.scrollX - padding}px`;
+  overlay.style.width = `${rect.width + padding * 2}px`;
+  overlay.style.height = `${rect.height + padding * 2}px`;
+  overlay.style.border = '2px dashed red';
+  overlay.style.zIndex = 999999;
+  overlay.style.pointerEvents = 'none';
+  return overlay;
+}
+
+function removeOverlay() {
+  if (currentOverlay) {
+    currentOverlay.remove();
+    currentOverlay = null;
+  }
+}
+
+function mouseOverHandler(e) {
+  if (currentTarget) return;
+  removeOverlay();
+  const rect = e.target.getBoundingClientRect();
+  currentOverlay = createOverlay(rect);
+  document.body.appendChild(currentOverlay);
+}
+
+function clickHandler(e) {
+  e.preventDefault();
+  e.stopPropagation();
+  currentTarget = e.target;
+  captureSelected();
+  cleanup();
+}
+
+function cleanup() {
+  removeOverlay();
+  document.removeEventListener('mouseover', mouseOverHandler, true);
+  document.removeEventListener('click', clickHandler, true);
+}
+
+function captureSelected() {
+  const rect = currentTarget.getBoundingClientRect();
+  chrome.runtime.sendMessage({
+    type: 'capture',
+    rect: {
+      top: rect.top + window.scrollY,
+      left: rect.left + window.scrollX,
+      width: rect.width,
+      height: rect.height
+    },
+    padding,
+    viewport: {
+      width: window.innerWidth,
+      height: window.innerHeight,
+      scrollX: window.scrollX,
+      scrollY: window.scrollY
+    }
+  });
+}
+
+chrome.runtime.onMessage.addListener((message) => {
+  if (message.type === 'start-selection') {
+    padding = message.padding || 0;
+    currentTarget = null;
+    document.addEventListener('mouseover', mouseOverHandler, true);
+    document.addEventListener('click', clickHandler, true);
+  }
+});

--- a/hello.html
+++ b/hello.html
@@ -1,6 +1,0 @@
-<html>
-  <body>
-    <h1>Hello Extensions</h1>
-    <script src="popup.js"></script>
-  </body>
-</html>

--- a/manifest.json
+++ b/manifest.json
@@ -1,10 +1,13 @@
 {
-  "name": "Hello Extensions",
-  "description": "Base Level Extension",
-  "version": "1.0",
+  "name": "ReviewIt",
+  "description": "Capture DOM blocks and compare with Figma",
+  "version": "0.1",
   "manifest_version": 3,
   "action": {
-    "default_popup": "hello.html",
+    "default_popup": "popup.html",
     "default_icon": "hello_extensions.png"
-  }
+  },
+  "permissions": ["activeTab", "scripting", "storage", "tabs"],
+  "background": {"service_worker": "background.js"},
+  "host_permissions": ["https://www.figma.com/*"]
 }

--- a/popup.html
+++ b/popup.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      min-width: 300px;
+      padding: 10px;
+    }
+    #screenshot {
+      margin-top: 10px;
+      max-width: 100%;
+      border: 1px solid #ccc;
+    }
+  </style>
+</head>
+<body>
+  <h1>ReviewIt</h1>
+  <div>
+    <label>Padding (px): <input id="padding" type="number" value="40" /></label>
+  </div>
+  <div>
+    <label>Figma Link: <input id="figmaLink" type="text" placeholder="https://figma.com/..." /></label>
+  </div>
+  <button id="start">Start Selection</button>
+  <div>
+    <img id="screenshot" />
+  </div>
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/popup.js
+++ b/popup.js
@@ -1,1 +1,24 @@
-console.log("This is a popup!");
+async function getCurrentTab() {
+  let [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+  return tab;
+}
+
+document.getElementById('start').addEventListener('click', async () => {
+  const padding = parseInt(document.getElementById('padding').value, 10) || 0;
+  const figmaLink = document.getElementById('figmaLink').value;
+
+  const tab = await getCurrentTab();
+  chrome.storage.local.set({ figmaLink });
+  await chrome.scripting.executeScript({
+    target: { tabId: tab.id },
+    files: ['contentScript.js']
+  });
+  chrome.tabs.sendMessage(tab.id, { type: 'start-selection', padding });
+});
+
+chrome.runtime.onMessage.addListener((message) => {
+  if (message.type === 'screenshot-captured') {
+    const img = document.getElementById('screenshot');
+    img.src = message.dataUrl;
+  }
+});


### PR DESCRIPTION
## Summary
- rename popup file
- implement popup UI for padding input and Figma link
- add script to select DOM blocks and capture screenshot with padding
- hook up background service worker to crop screenshot
- update manifest to register service worker and permissions

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6846f77737108329ad5f907dde80eb71