### PR TITLE
Fix screenshot capturing and script reinjection

### DIFF
--- a/background.js
+++ b/background.js
@@ -4,37 +4,39 @@ chrome.runtime.onMessage.addListener(async (message, sender, sendResponse) => {
     const imageUri = await chrome.tabs.captureVisibleTab(sender.tab.windowId, {
       format: 'png'
     });
-    const img = new Image();
-    img.src = imageUri;
-    img.onload = () => {
-      const canvas = new OffscreenCanvas(message.rect.width + message.padding * 2,
-        message.rect.height + message.padding * 2);
-      const ctx = canvas.getContext('2d');
-      ctx.drawImage(
-        img,
-        message.rect.left - message.padding,
-        message.rect.top - message.padding,
-        canvas.width,
-        canvas.height,
-        0,
-        0,
-        canvas.width,
-        canvas.height
-      );
-      canvas.convertToBlob({ type: 'image/png' }).then(blob => {
-        const reader = new FileReader();
-        reader.onload = () => {
-          const message = {
-            type: 'screenshot-captured',
-            dataUrl: reader.result
-          };
-          // send to content script on the page
-          chrome.tabs.sendMessage(tabId, message);
-          // also notify popup or other extension pages
-          chrome.runtime.sendMessage(message);
-        };
-        reader.readAsDataURL(blob);
-      });
+    const response = await fetch(imageUri);
+    const blob = await response.blob();
+    const imgBitmap = await createImageBitmap(blob);
+
+    const canvas = new OffscreenCanvas(
+      message.rect.width + message.padding * 2,
+      message.rect.height + message.padding * 2
+    );
+    const ctx = canvas.getContext('2d');
+    ctx.drawImage(
+      imgBitmap,
+      message.rect.left - message.viewport.scrollX - message.padding,
+      message.rect.top - message.viewport.scrollY - message.padding,
+      canvas.width,
+      canvas.height,
+      0,
+      0,
+      canvas.width,
+      canvas.height
+    );
+
+    const blobOut = await canvas.convertToBlob({ type: 'image/png' });
+    const reader = new FileReader();
+    reader.onload = () => {
+      const outMessage = {
+        type: 'screenshot-captured',
+        dataUrl: reader.result
+      };
+      // send to content script on the page
+      chrome.tabs.sendMessage(tabId, outMessage);
+      // also notify popup or other extension pages
+      chrome.runtime.sendMessage(outMessage);
     };
+    reader.readAsDataURL(blobOut);
   }
 });

--- a/contentScript.js
+++ b/contentScript.js
@@ -1,8 +1,14 @@
-let currentOverlay;
-let currentTarget;
-let capturePadding = 0;
-let hoverPadding = 0;
-let linkInterceptor;
+(() => {
+  if (window.reviewItInjected) {
+    return;
+  }
+  window.reviewItInjected = true;
+
+  let currentOverlay;
+  let currentTarget;
+  let capturePadding = 0;
+  let hoverPadding = 0;
+  let linkInterceptor;
 
 function createOverlay(rect, pad) {
   const overlay = document.createElement('div');
@@ -185,3 +191,5 @@ chrome.runtime.onMessage.addListener((message) => {
     showDialog(message.dataUrl);
   }
 });
+
+})();


### PR DESCRIPTION
## Summary
- prevent duplicate injection of content script to avoid redeclaration errors
- use `createImageBitmap` in the background service worker instead of DOM `Image`
- adjust screenshot cropping using viewport scroll offsets

## Testing
- `None`

------
https://chatgpt.com/codex/tasks/task_b_6846fda9b7b0832985daf247ba855f38